### PR TITLE
Rust Scrypt deprecation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,6 @@ name = "emerald_rs"
 path = "src/lib.rs"
 #crate-type = ["rlib", "cdylib"]
 
-[target.'cfg(unix)'.dependencies]
-rust-scrypt = "1.0"
-
 [dependencies]
 time = "0.1"
 futures = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,8 +32,6 @@ extern crate num;
 extern crate rand;
 extern crate regex;
 extern crate reqwest;
-#[cfg(all(unix))]
-extern crate rust_scrypt;
 extern crate rustc_serialize;
 extern crate secp256k1;
 extern crate serde;


### PR DESCRIPTION
This PR aims to replace rust-scrypt crate with the pure rust `scrypt` crate implementation for all platforms.

@r8d8 is there a reason to maintain rust-scrypt and not do this transition on unix?